### PR TITLE
Fix Freecoin transfer menu throwing errors on client

### DIFF
--- a/lua/fsb/client/cl_freemoney.lua
+++ b/lua/fsb/client/cl_freemoney.lua
@@ -31,6 +31,7 @@ function FSB.OpenMoneySendDialog(ply)
 			submit_btn:SetColor(FAIL_COLOR)
 		end
 		timer.Simple(MONEY_RATELIMIT, function ()
+			if not panel:IsValid() then return end
 			balance:SetText(FSB.Translate("money.your_balance", LocalPlayer():GetBalance()))
 			if submit_btn:IsValid() then
 				submit_btn:SetEnabled(true)


### PR DESCRIPTION
This is very bandaid.
Prior to this, it would script error with:
[freesbox] addons/freesbox/lua/fsb/client/cl_freemoney.lua:34: Tried to use a NULL Panel!
  1. SetText - [C]:-1
   2. unknown - addons/freesbox/lua/fsb/client/cl_freemoney.lua:34

Timer Failed! [Simple][@addons/freesbox/lua/fsb/client/cl_freemoney.lua (line 33)]
A simple IsValid check won't harm, hopefully. The balance is refreshed when reopening the menu, so it won't show stale data because this is timer check is for live updates.