### PR TITLE
KILL Actmod and replace it with VRMod (#1445)

### DIFF
--- a/lua/fsb/server/sv_workshop_dl.lua
+++ b/lua/fsb/server/sv_workshop_dl.lua
@@ -12,6 +12,7 @@ resource.AddWorkshop("3656294025") -- Glide // Combine APC
 resource.AddWorkshop("3656920709") -- Glide // Combine Dropship
 resource.AddWorkshop("3620753374") -- Left 4 Dead // Glide 
 resource.AddWorkshop("246756300") -- 3D Stream Radio
+resource.AddWorkshop("1678408548") -- VRMod
 resource.AddWorkshop("2675972006") -- Custom Loadout
 resource.AddWorkshop("3318060741") -- rRadio
 resource.AddWorkshop("104575630") -- Ragdoll Mover


### PR DESCRIPTION
I assume the reason Actmod is on the server right now is because it's using an older version of the file?
We have to wait until that petition passes